### PR TITLE
feat: adds a "local" keyserver

### DIFF
--- a/cmd/cacheserver/main.go
+++ b/cmd/cacheserver/main.go
@@ -9,10 +9,14 @@ import (
 	"fmt"
 	"os"
 
+	"upspin.io/bind"
 	"upspin.io/config"
 	"upspin.io/flags"
 	"upspin.io/log"
+	"upspin.io/upspin"
 	"upspin.io/version"
+
+	"upspin.io/key/inprocess"
 )
 
 const cmdName = "cacheserver"
@@ -30,6 +34,20 @@ func main() {
 	cfg, err := config.FromFile(flags.Config)
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	// XXX: why is this needed?
+	if cfg.KeyEndpoint().Transport == upspin.Local {
+		f := string(cfg.KeyEndpoint().NetAddr)
+		o, err := os.Open(f)
+		if err != nil {
+			return
+		}
+		s, err := inprocess.NewRO(o)
+		if err != nil {
+			return
+		}
+		bind.RegisterKeyServer(upspin.Local, s)
 	}
 
 	// Set any flags contained in the config.

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -177,7 +177,7 @@ var flags = map[string]*flagVar{
 			return ""
 		},
 	},
-	"kind":      strVar(&ServerKind, "kind", ServerKind, "server implementation `kind` (inprocess, server)"),
+	"kind":      strVar(&ServerKind, "kind", ServerKind, "server implementation `kind` (inprocess, server, local[keyserver only])"),
 	"letscache": strVar(&LetsEncryptCache, "letscache", defaultLetsEncryptCache, "Let's Encrypt cache `directory`"),
 	"log": &flagVar{
 		set: func(fs *flag.FlagSet) {
@@ -230,10 +230,11 @@ var flags = map[string]*flagVar{
 // The Server and Client variables contain useful default sets.
 //
 // Examples:
-// 	flags.Parse(flags.Client) // Register all client flags.
+//
+//	flags.Parse(flags.Client) // Register all client flags.
 //	flags.Parse(flags.Server, "cachedir") // Register all server flags plus cachedir.
-// 	flags.Parse(nil) // Register all flags.
-// 	flags.Parse(flags.None, "config", "endpoint") // Register only config and endpoint.
+//	flags.Parse(nil) // Register all flags.
+//	flags.Parse(flags.None, "config", "endpoint") // Register only config and endpoint.
 func Parse(defaultList []string, extras ...string) {
 	ParseArgsInto(flag.CommandLine, os.Args[1:], defaultList, extras...)
 }
@@ -273,9 +274,12 @@ func ParseArgsInto(fs *flag.FlagSet, args, defaultList []string, extras ...strin
 // Passing an unknown name triggers a panic.
 //
 // For example:
-// 	flags.Register("config", "endpoint") // Register Config and Endpoint.
+//
+//	flags.Register("config", "endpoint") // Register Config and Endpoint.
+//
 // or
-// 	flags.Register() // Register all flags.
+//
+//	flags.Register() // Register all flags.
 func Register(names ...string) {
 	RegisterInto(flag.CommandLine, names...)
 }

--- a/key/inprocess/key.go
+++ b/key/inprocess/key.go
@@ -6,6 +6,9 @@
 package inprocess // import "upspin.io/key/inprocess"
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
 	"sync"
 
 	"upspin.io/errors"
@@ -20,11 +23,24 @@ func New() upspin.KeyServer {
 	}}
 }
 
+func NewRO(r io.Reader) (upspin.KeyServer, error) {
+	s := &server{db: &database{
+		users: make(map[upspin.UserName]*upspin.User),
+	},
+		readOnly: true,
+	}
+	if err := s.fill(r); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
 // server maps user names to potential machines holding root of the user's tree.
 // There is one for each Dial call, but they all share the underlying database.
 // It implements the upspin.KeyServer interface.
 type server struct {
-	db *database
+	db       *database
+	readOnly bool
 }
 
 var _ upspin.KeyServer = (*server)(nil)
@@ -70,6 +86,9 @@ func dup(u *upspin.User) *upspin.User {
 // Put implements upspin.KeyServer.
 func (s *server) Put(u *upspin.User) error {
 	const op errors.Op = "key/inprocess.Put"
+	if s.readOnly {
+		return errors.E(op, errors.Invalid, u.Name, "this is a read-only keyserver")
+	}
 	if err := valid.User(u); err != nil {
 		return errors.E(op, err)
 	}
@@ -107,4 +126,36 @@ func (s *server) Dial(config upspin.Config, e upspin.Endpoint) (upspin.Service, 
 
 // Close implements upspin.server.
 func (s *server) Close() {
+}
+
+type UserData struct {
+	Name      string `json:"name"`
+	PublicKey string `json:"key"`
+}
+
+type KeyData struct {
+	Users []UserData `json:"users"`
+}
+
+func (s *server) fill(r io.Reader) error {
+	s.readOnly = false // Temporarily.
+	defer func() {
+		s.readOnly = true
+	}()
+
+	j := json.NewDecoder(r)
+	var k KeyData
+	if err := j.Decode(&k); err != nil {
+		return fmt.Errorf("could not decode user key data: %w", err)
+	}
+	for _, d := range k.Users {
+		u := &upspin.User{
+			Name:      upspin.UserName(d.Name),
+			PublicKey: upspin.PublicKey(d.PublicKey),
+		}
+		if err := s.Put(u); err != nil {
+			return fmt.Errorf("while filling readonly keyserver: %w", err)
+		}
+	}
+	return nil
 }

--- a/key/remote/remote.go
+++ b/key/remote/remote.go
@@ -83,15 +83,11 @@ func (r *remote) Endpoint() upspin.Endpoint {
 func (r *remote) Dial(config upspin.Config, e upspin.Endpoint) (upspin.Service, error) {
 	op := r.opf("Dial", "%q, %q", config.UserName(), e)
 
-	if e.Transport != upspin.Remote && e.Transport != upspin.LocalInsecure {
+	if e.Transport != upspin.Remote {
 		return nil, op.error(errors.Invalid, "unrecognized transport")
 	}
 
 	l := rpc.Secure
-	if e.Transport == upspin.LocalInsecure {
-		l = rpc.NoSecurity
-	}
-
 	authClient, err := rpc.NewClient(config, e.NetAddr, l, upspin.Endpoint{})
 	if err != nil {
 		return nil, op.error(errors.IO, err)

--- a/key/remote/remote.go
+++ b/key/remote/remote.go
@@ -83,11 +83,16 @@ func (r *remote) Endpoint() upspin.Endpoint {
 func (r *remote) Dial(config upspin.Config, e upspin.Endpoint) (upspin.Service, error) {
 	op := r.opf("Dial", "%q, %q", config.UserName(), e)
 
-	if e.Transport != upspin.Remote {
+	if e.Transport != upspin.Remote && e.Transport != upspin.LocalInsecure {
 		return nil, op.error(errors.Invalid, "unrecognized transport")
 	}
 
-	authClient, err := rpc.NewClient(config, e.NetAddr, rpc.Secure, upspin.Endpoint{})
+	l := rpc.Secure
+	if e.Transport == upspin.LocalInsecure {
+		l = rpc.NoSecurity
+	}
+
+	authClient, err := rpc.NewClient(config, e.NetAddr, l, upspin.Endpoint{})
 	if err != nil {
 		return nil, op.error(errors.IO, err)
 	}

--- a/transports/transports.go
+++ b/transports/transports.go
@@ -9,10 +9,13 @@
 package transports // import "upspin.io/transports"
 
 import (
+	"fmt"
+	"os"
 	"sync"
 
 	"upspin.io/bind"
 	"upspin.io/dir/inprocess"
+	kinp "upspin.io/key/inprocess"
 	"upspin.io/upspin"
 
 	_ "upspin.io/key/transports"
@@ -38,6 +41,22 @@ func Init(cfg upspin.Config) {
 	if cfg.DirEndpoint().Transport == upspin.InProcess {
 		bindOnce.Do(func() {
 			bind.RegisterDirServer(upspin.InProcess, inprocess.New(cfg))
+		})
+	}
+	if cfg.KeyEndpoint().Transport == upspin.Local {
+		f := string(cfg.KeyEndpoint().NetAddr)
+		o, err := os.Open(f)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oops: %v", err)
+			return
+		}
+		bindOnce.Do(func() {
+			s, err := kinp.NewRO(o)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "oops2: %v", err)
+				return
+			}
+			bind.RegisterKeyServer(upspin.Local, s)
 		})
 	}
 }

--- a/upspin/code.go
+++ b/upspin/code.go
@@ -497,6 +497,8 @@ func (t Transport) String() string {
 		return "inprocess"
 	case Remote:
 		return "remote"
+	case Local:
+		return "local"
 	default:
 		return fmt.Sprintf("transport(%d)", int(t))
 	}

--- a/upspin/endpoint.go
+++ b/upspin/endpoint.go
@@ -21,11 +21,6 @@ func ParseEndpoint(v string) (*Endpoint, error) {
 			return nil, fmt.Errorf("remote endpoint %q requires a netaddr", v)
 		}
 		return &Endpoint{Transport: Remote, NetAddr: NetAddr(elems[1])}, nil
-	case "localinsecure":
-		if len(elems) < 2 {
-			return nil, fmt.Errorf("remote endpoint %q requires a netaddr", v)
-		}
-		return &Endpoint{Transport: LocalInsecure, NetAddr: NetAddr(elems[1])}, nil
 	case "local":
 		if len(elems) < 2 {
 			return nil, fmt.Errorf("local endpoint %q requires a netaddr", v)

--- a/upspin/endpoint.go
+++ b/upspin/endpoint.go
@@ -21,6 +21,11 @@ func ParseEndpoint(v string) (*Endpoint, error) {
 			return nil, fmt.Errorf("remote endpoint %q requires a netaddr", v)
 		}
 		return &Endpoint{Transport: Remote, NetAddr: NetAddr(elems[1])}, nil
+	case "local":
+		if len(elems) < 2 {
+			return nil, fmt.Errorf("local endpoint %q requires a netaddr", v)
+		}
+		return &Endpoint{Transport: Local, NetAddr: NetAddr(elems[1])}, nil
 	case "unassigned":
 		return &Endpoint{Transport: Unassigned}, nil
 	}

--- a/upspin/endpoint.go
+++ b/upspin/endpoint.go
@@ -21,6 +21,11 @@ func ParseEndpoint(v string) (*Endpoint, error) {
 			return nil, fmt.Errorf("remote endpoint %q requires a netaddr", v)
 		}
 		return &Endpoint{Transport: Remote, NetAddr: NetAddr(elems[1])}, nil
+	case "localinsecure":
+		if len(elems) < 2 {
+			return nil, fmt.Errorf("remote endpoint %q requires a netaddr", v)
+		}
+		return &Endpoint{Transport: LocalInsecure, NetAddr: NetAddr(elems[1])}, nil
 	case "local":
 		if len(elems) < 2 {
 			return nil, fmt.Errorf("local endpoint %q requires a netaddr", v)

--- a/upspin/upspin.go
+++ b/upspin/upspin.go
@@ -44,6 +44,9 @@ const (
 
 	// An endpoint that uses local data, and does not really dial out.
 	Local
+
+	// An endpoint served through insecure means.  Use only for localhost.
+	LocalInsecure
 )
 
 // A Location identifies where a piece of data is stored and how to retrieve it.

--- a/upspin/upspin.go
+++ b/upspin/upspin.go
@@ -41,6 +41,9 @@ const (
 	// (Although called remote, the service may be running on the same machine.)
 	// The Endpoint's NetAddr contains the HTTP address of the server.
 	Remote
+
+	// An endpoint that uses local data, and does not really dial out.
+	Local
 )
 
 // A Location identifies where a piece of data is stored and how to retrieve it.
@@ -774,7 +777,7 @@ type Client interface {
 	// not the link target.
 	SetTime(name PathName, t Time) error
 
-	// SetTimeSequenced sets the time in name's DirEntry. 
+	// SetTimeSequenced sets the time in name's DirEntry.
 	// SetTimeSequenced with SeqIgnore is the same as SetTime.
 	//
 	// A successful SetTimeSequenced returns an incomplete DirEntry (see the

--- a/upspin/upspin.go
+++ b/upspin/upspin.go
@@ -44,9 +44,6 @@ const (
 
 	// An endpoint that uses local data, and does not really dial out.
 	Local
-
-	// An endpoint served through insecure means.  Use only for localhost.
-	LocalInsecure
 )
 
 // A Location identifies where a piece of data is stored and how to retrieve it.


### PR DESCRIPTION
A local keyserver is only really serving local key data, and in a read-only mode. This is a stopgap measure until a proper keyserver implementation is created.

Example below.

Config file at: `$HOME/upspin/configs/keytest.config`:
```
username: user@example.com
secrets: /home/someuser/.ssh/user@example.com
keyserver: local,/home/user/upspin/configs/users.json
packing: ee
cache: yes
```

Then, in `/home/user/upspin/configs/users.json`:

```json
{
    "users": [
       {
           "name": "user@example.com",
           "key": "key here"
       }
    ]
}
```

Then start the keyserver for example as:

```
./keyserver \
   -config $HOME/upspin/configs/keytest.config \
   -http localhost:8080 \
   -kind local \
   -http :8080 \
   -https :3443
   -insecure
```

The `-insecure` allows serving key data through HTTP. This should be OK
in a sandboxed environment.