### PR TITLE
🎨 Palette: Add proper HTML structure and lang attribute to base template

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-18 - Added Proper Document Structure and Language Attribute to Templates
+**Learning:** Found a base template (`doc/templates/base.tmpl`) that was missing `<html lang="en">`, `<head>`, and `<body>` tags. This creates invalid HTML which can degrade the experience for assistive technologies like screen readers, which rely on the `lang` attribute for proper pronunciation and correct document structure for semantic navigation.
+**Action:** Always ensure foundational layout components/templates contain standard HTML structure and the correct `lang` attribute in future implementations.

--- a/doc/templates/base.tmpl
+++ b/doc/templates/base.tmpl
@@ -1,9 +1,11 @@
 <!DOCTYPE html>
+<html lang="en">
 <!--
 Copyright 2017 The Upspin Authors. All rights reserved.
 Use of this source code is governed by a BSD-style
 license that can be found in the LICENSE file.
 -->
+<head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <script>
@@ -66,6 +68,8 @@ blockquote {
 }
 {{block "styles" .}}{{end}}
 </style>
+</head>
+<body>
 <main>
   <div class="container">
     {{block "before-content" .}}{{end}}
@@ -91,3 +95,5 @@ blockquote {
     <a href="http://www.google.com/intl/en/policies/privacy/">Privacy Policy</a>
   </div>
 </footer>
+</body>
+</html>


### PR DESCRIPTION
🎨 Palette: Add proper HTML structure and lang attribute to base template

💡 What: Added missing `<html>`, `<head>`, and `<body>` tags to `doc/templates/base.tmpl` and set the `lang="en"` attribute.
🎯 Why: Without these tags, the HTML is invalid. More importantly, missing the `lang` attribute makes it difficult for screen readers and other assistive technologies to correctly pronounce the document's content.
♿ Accessibility: Ensures proper semantic structure and provides the necessary language context for screen readers.

---
*PR created automatically by Jules for task [5957202215472759802](https://jules.google.com/task/5957202215472759802) started by @filmil*