### PR TITLE
⚡ Bolt: Single block zero-copy optimization in ReadAll

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2023-10-24 - Zero-copy fast path in File Reader
+**Learning:** Returning exactly-sized slices produced by unpackers avoids a memory copy (append) when a file consists of a single block. Since most files are single blocks, this saves an allocation and copy on a hot path.
+**Action:** Always check if a slice can be returned directly instead of accumulating it into a larger buffer when the data is known to fit entirely in one segment.

--- a/client/clientutil/readall.go
+++ b/client/clientutil/readall.go
@@ -57,7 +57,10 @@ func ReadAll(cfg upspin.Config, entry *upspin.DirEntry) ([]byte, error) {
 		if err != nil {
 			return nil, errors.E(entry.Name, err)
 		}
-		data = append(data, clear...) // TODO: Could avoid a copy if only one block.
+		if len(entry.Blocks) == 1 {
+			return clear, nil
+		}
+		data = append(data, clear...)
 	}
 	return data, nil
 }


### PR DESCRIPTION
💡 What: Returns the unpacked `clear` slice directly in `client/clientutil.ReadAll` if `len(entry.Blocks) == 1`.
🎯 Why: Avoids a completely unnecessary allocation and memory copy (`append(data, clear...)`) when the file is composed of exactly one block (which is typical for many files).
📊 Impact: Saves an allocation and memory copy per file read for all single-block files, reducing garbage collection pressure and speeding up file access.
🔬 Measurement: Covered by `go test ./client/clientutil/...`. This effectively resolves an inline TODO: `// TODO: Could avoid a copy if only one block.`.

---
*PR created automatically by Jules for task [17505067877590595591](https://jules.google.com/task/17505067877590595591) started by @filmil*