### PR TITLE
ci: add GitHub Actions workflow and fix brittle TestDebug

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Go Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  test:
+    name: Run Go Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: true
+
+      - name: Run tests
+        run: go test -v -short ./...

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Upspin (maintained)
+
+[![Go Test](https://github.com/filmil/upspin/actions/workflows/test.yml/badge.svg)](https://github.com/filmil/upspin/actions/workflows/test.yml)
+
+---
+
 2025-02-11 announcement: Turning down Upspin infrastructure 
 
 Upspin, like Unix and Plan 9, was intended to foster communities of sharing, but has been less successful at that than we hoped. As a consequence, with regret, we have decided to turn down the central infrastructure such as the keyserver over the coming months 

--- a/errors/debug_test.go
+++ b/errors/debug_test.go
@@ -18,10 +18,10 @@ import (
 )
 
 var errorLines = strings.Split(strings.TrimSpace(`
-	.*/upspin.io/errors/debug_test.go:\d+: upspin.io/errors_test..*
-	.*/upspin.io/errors/debug_test.go:\d+: .*
-	.*/upspin.io/valid/valid.go:\d+: .*valid.UserName:
-	.*/upspin.io/user/user.go:\d+: ...user.Parse: op: user@home/path: invalid operation:
+	.*errors/debug_test.go:\d+: upspin.io/errors_test..*
+	.*errors/debug_test.go:\d+: .*
+	.*valid/valid.go:\d+: .*valid.UserName:
+	.*user/user.go:\d+: ...user.Parse: op: user@home/path: invalid operation:
 	valid.UserName:
 	user.Parse: user bad-username: user name must contain one @ symbol
 `), "\n")


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to run tests on PRs, merges to main, and once a month. It also fixes a brittle test in the errors package that was failing due to environment-specific path expectations and adds a status badge to the README.

### Changes:
- Added `.github/workflows/test.yml` configured to run `go test -v -short ./...`.
- Modified `errors/debug_test.go` to allow for flexible file paths in `TestDebug`.
- Prepended a status badge and "maintained" header to `README.md`.

This pull request has been created by an automated coding assistant, with human supervision.

Prompt: create PR