### PR TITLE
ci: add workflows for tagging, releasing, and publishing to BCR

### DIFF
--- a/.github/workflows/publish-bcr.yml
+++ b/.github/workflows/publish-bcr.yml
@@ -1,0 +1,32 @@
+name: "Publish on Bazel Central Registry"
+
+on:
+  workflow_call:
+    secrets:
+      BCR_PUBLISH_TOKEN:
+        required: false
+        description: 'Optional token for BCR publishing.'
+    inputs:
+      tag_name:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Tag to publish"
+        required: true
+        type: string
+
+jobs:
+  publish:
+    uses: "bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v0.2.2"
+    with:
+      tag_name: ${{ inputs.tag_name }}
+      registry_fork: filmil/bazel-central-registry
+      attest: false
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    secrets:
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: "Publish to my Bazel registry"
+
+on:
+  workflow_call:
+    secrets:
+      BCR_PUBLISH_TOKEN:
+        required: false
+        description: 'Optional token for BCR publishing.'
+    inputs:
+      tag_name:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Tag to publish"
+        required: true
+        type: string
+
+jobs:
+  publish:
+    uses: "bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v0.2.2"
+    with:
+      tag_name: ${{ inputs.tag_name }}
+      registry: filmil/bazel-registry
+      registry_fork: filmil/bazel-registry
+      attest: false
+      draft: false
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    secrets:
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -1,0 +1,127 @@
+name: Tag and Release
+
+on:
+  schedule:
+    - cron: '0 0 20 * *'
+  workflow_dispatch:
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.tag_version.outputs.new_tag }}
+    steps:
+      - name: Setup bazel
+        uses: bazel-contrib/setup-bazel@0.8.5
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: "~/.cache/bazel"
+          key: ${{ runner.os }}-bazel-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-bazel-
+      - name: "Test"
+        run: "bazel test --test_output=errors //..."
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          release_branches: main
+      - name: Create a GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          generateReleaseNotes: true
+      - name: Get release tag
+        id: get_version
+        run: echo "VERSION=${{ steps.tag_version.outputs.new_tag }}" >> $GITHUB_ENV
+      - name: Get repo name
+        id: get_repo_name
+        run: echo "REPO_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')" >> $GITHUB_ENV
+      - name: "Publish source archive"
+        uses: thedoctor0/zip-release@0.7.5
+        with:
+          type: 'zip'
+          filename: "${{ env.REPO_NAME }}-${{ env.VERSION }}.zip"
+          exclusions: '*.git* /*node_modules/* .editorconfig /bazel-*'
+      - name: "Upload source archive"
+        uses: ncipollo/release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          allowUpdates: true
+          artifacts: "${{ env.REPO_NAME }}-${{ env.VERSION }}.zip"
+
+  release:
+    needs: tag
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: ["amd64", "arm64"]
+        os: ["linux", "darwin", "windows"]
+    steps:
+      - name: Setup bazel
+        uses: bazel-contrib/setup-bazel@0.8.5
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: "~/.cache/bazel"
+          key: ${{ runner.os }}-${{ matrix.arch }}-bazel-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.arch }}-bazel-
+      - name: "Build binaries for ${{ matrix.os }}_${{ matrix.arch }}"
+        run: |
+          TARGETS=$(bazel query 'kind("go_binary", //cmd/...)')
+          bazel build --platforms=@rules_go//go/toolchain:${{ matrix.os }}_${{ matrix.arch }} $(echo $TARGETS)
+      - name: "Package binaries"
+        run: |
+          mkdir -p release-binaries
+          TARGETS=$(bazel query 'kind("go_binary", //cmd/...)')
+          FILES=$(bazel cquery "set($TARGETS)" --platforms=@rules_go//go/toolchain:${{ matrix.os }}_${{ matrix.arch }} --output=files 2>/dev/null | grep bazel-out)
+          cp $FILES release-binaries/
+          zip -j -r upspin-binaries-${{ matrix.os }}-${{ matrix.arch }}.zip release-binaries/
+      - name: Find version tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          release_branches: main
+          dry_run: true
+      - name: "Publish ${{ matrix.os }}_${{ matrix.arch }}"
+        uses: ncipollo/release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          allowUpdates: true
+          artifacts: "upspin-binaries-${{ matrix.os }}-${{ matrix.arch }}.zip"
+          tag: ${{ steps.tag_version.outputs.previous_tag }}
+
+  publish-my-registry:
+    needs: tag
+    uses: ./.github/workflows/publish.yml
+    with:
+      tag_name: ${{ needs.tag.outputs.tag_name }}
+    secrets:
+      BCR_PUBLISH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}
+
+  publish-bcr:
+    needs: tag
+    uses: ./.github/workflows/publish-bcr.yml
+    with:
+      tag_name: ${{ needs.tag.outputs.tag_name }}
+    secrets:
+      BCR_PUBLISH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}


### PR DESCRIPTION
This PR adds GitHub Actions workflows modeled after `filmil/bazel-go-basic` to:

1. Build cross-platform binaries (`linux`, `darwin`, `windows` across `amd64` and `arm64`) for all executable targets under `//cmd/...`.
2. Zip up these built binaries dynamically via Bazel `query` and `cquery`.
3. Create a GitHub Release with the zipped binary assets and source archives.
4. Publish to `filmil/bazel-registry` and the Bazel Central Registry (`filmil/bazel-central-registry`).

This pull request has been created by an automated coding assistant, with human supervision.

Prompt:
new PR: use example workflows at https://github.com/filmil/bazel-go-basic to add similar workflows to release binaries, and publish to my registry and bcr. note all binaries that are available at //cmd/..., and modify the release process to build binaries for all of them