### PR TITLE
build: add .bcr directory for Bazel Central Registry publishing

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,18 @@
+{
+  "homepage": "https://github.com/filmil/upspin",
+  "maintainers": [
+    {
+      "name": "Filip Filmar",
+      "email": "246576+filmil@users.noreply.github.com",
+      "github": "filmil",
+      "github_user_id": 246576
+    }
+  ],
+  "repository": [
+    "github:filmil/upspin"
+  ],
+  "versions": [
+    "0.0.1"
+  ],
+  "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,10 @@
+matrix:
+  platform: ["ubuntu2204"]
+  bazel: [8.x]
+tasks:
+  run_tests:
+    name: "Run tests"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_targets:
+      - "//..."

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "",
+  "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{TAG}.tar.gz"
+}


### PR DESCRIPTION
This PR adds the `.bcr` directory to support publishing this module to the Bazel Central Registry.

The configuration includes:
- `metadata.template.json` with repository and maintainer information.
- `presubmit.yml` defining the test matrix for Bazel.
- `source.template.json` for mapping the GitHub release archive.
- An empty `config.yml`.

These files were adapted from `bazel-go-basic` to fit the current project structure.

This pull request has been created by an automated coding assistant, with human supervision.
Prompt: in a new worktree add a .bcr dir using example at https://github.com/filmil/bazel-go-basic/tree/main/.bcr, adapt what needs adapting
Prompt: send pr
