### PR TITLE
docs: add remaining workflow status badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Upspin (maintained)
 
 [![Bazel Build and Test](https://github.com/filmil/upspin/actions/workflows/bazel.yml/badge.svg)](https://github.com/filmil/upspin/actions/workflows/bazel.yml)
+[![Tag and Release](https://github.com/filmil/upspin/actions/workflows/tag-and-release.yml/badge.svg)](https://github.com/filmil/upspin/actions/workflows/tag-and-release.yml)
+[![Publish to my Bazel registry](https://github.com/filmil/upspin/actions/workflows/publish.yml/badge.svg)](https://github.com/filmil/upspin/actions/workflows/publish.yml)
+[![Publish on Bazel Central Registry](https://github.com/filmil/upspin/actions/workflows/publish-bcr.yml/badge.svg)](https://github.com/filmil/upspin/actions/workflows/publish-bcr.yml)
 
 ---
 


### PR DESCRIPTION
Add status badges for the remaining GitHub workflows: Tag and Release, Publish to my Bazel registry, and Publish on Bazel Central Registry.

This pull request has been created by an automated coding assistant, with human supervision.

Prompt:
send new pr for this