### PR TITLE
ci: make BCR publishing manual and only push to personal registry automatically

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -134,10 +134,3 @@ jobs:
     secrets:
       BCR_PUBLISH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}
 
-  publish-bcr:
-    needs: tag
-    uses: ./.github/workflows/publish-bcr.yml
-    with:
-      tag_name: ${{ needs.tag.outputs.tag_name }}
-    secrets:
-      BCR_PUBLISH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}


### PR DESCRIPTION
This PR updates the `.github/workflows/tag-and-release.yml` file to remove the automatic publishing step to the Bazel Central Registry (BCR). The workflow will now only publish to the custom registry automatically upon release.

Publishing to the BCR must now be done manually by triggering the `Publish on Bazel Central Registry` (`publish-bcr.yml`) workflow via `workflow_dispatch`.

This pull request has been created by an automated coding assistant, with human supervision.
Prompt: in new worktree modify https://github.com/filmil/upspin/blob/main/.github/workflows/tag-and-release.yml to only publish to my registry not bcr. bcr publication must only be manual
