### PR TITLE
docs: enforce running tests after each change in GEMINI.md

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -79,6 +79,8 @@ To run all tests:
 bazel test //...
 ```
 
+**CRITICAL RULE:** You must run all tests (`bazel test //...`) after making any code changes to ensure no regressions are introduced before concluding the task.
+
 ## Maintenance with Gazelle
 
 We use Gazelle to automatically generate and update `BUILD.bazel` files.


### PR DESCRIPTION
This PR updates the `GEMINI.md` file to explicitly enforce the requirement that all tests (`bazel test //...`) must be run after making any code changes, ensuring that no regressions are inadvertently introduced.

This pull request has been created by an automated coding assistant, with human supervision.
Prompt: add to GEMINI.md that tests must be run after each change
