### PR TITLE
test: ignore os.ErrNotExist in upspinfs TestCleanup

### DIFF
--- a/cmd/upspinfs/upspinfs_test.go
+++ b/cmd/upspinfs/upspinfs_test.go
@@ -752,6 +752,9 @@ func bytesUsed(t *testing.T, dir string) int64 {
 	var sum int64
 	fn := func(path string, info os.FileInfo, err error) error {
 		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
 			return err
 		}
 		sum += info.Size()


### PR DESCRIPTION
This pull request addresses an intermittent test failure in `cmd/upspinfs/upspinfs_test.go`'s `TestCleanup`.

**Summary of changes:**
- Modified the `filepath.Walk` callback within the `bytesUsed` function to explicitly ignore `os.IsNotExist` errors.
- This prevents the test from failing when concurrent cache eviction deletes a file between `readdir` and `lstat`.

This pull request has been created by an automated coding assistant, with human supervision.

Prompt: send pr