### PR TITLE
ci: disable windows binary builds in release workflow

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -97,7 +97,7 @@ jobs:
     strategy:
       matrix:
         arch: ["amd64", "arm64"]
-        os: ["linux", "darwin", "windows"]
+        os: ["linux", "darwin"] # "windows" commented out due to build issues
     steps:
       - name: Setup bazel
         uses: bazel-contrib/setup-bazel@0.8.5


### PR DESCRIPTION
ci: disable windows binary builds in release workflow

This PR modifies `.github/workflows/tag-and-release.yml` to remove `"windows"` from the OS matrix strategy since the Windows binaries are currently failing to build. 

This pull request has been created by an automated coding assistant, with human supervision.

Prompt:
in github workflows, comment out building windows binaries - they don't seem to build correctly
send pr
