### PR TITLE
feat: add local_keyserver to the release container image

### DIFF
--- a/containers/BUILD.bazel
+++ b/containers/BUILD.bazel
@@ -9,6 +9,7 @@ BINARIES = [
     "//cmd/dirserver",
     "//cmd/frontend",
     "//cmd/keyserver",
+    "//cmd/local_keyserver",
     "//cmd/storeserver",
     "//cmd/upbox",
     "//cmd/upspin",


### PR DESCRIPTION
This pull request adds `//cmd/local_keyserver` to the `BINARIES` list in `//containers/BUILD.bazel` so that it is included in the built OCI image.

This pull request has been created by an automated coding assistant, with human supervision.

Prompt: add //cmd/local_keyserver to the container in //containers