### PR TITLE
feat: enable multi-arch container builds for amd64 and arm64

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,9 +16,9 @@ oci.pull(
     name = "distroless_static",
     digest = "sha256:47b2d72ff90843eb8a768b5c2f89b40741843b639d065b9b937b07cd59b479c6",
     image = "gcr.io/distroless/static",
-    platforms = ["linux/amd64"],
+    platforms = ["linux/amd64", "linux/arm64/v8"],
 )
-use_repo(oci, "distroless_static", "distroless_static_linux_amd64")
+use_repo(oci, "distroless_static", "distroless_static_linux_amd64", "distroless_static_linux_arm64_v8")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.26.2")

--- a/containers/BUILD.bazel
+++ b/containers/BUILD.bazel
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "oci_push")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load(":transition.bzl", "multi_arch_image")
 
 # All binaries from //cmd/...
 BINARIES = [
@@ -31,9 +32,23 @@ oci_image(
     tars = [":binaries_tar"],
 )
 
+# This builds both linux_amd64 and linux_arm64 images.
+multi_arch_image(
+    name = "image_multi_arch",
+    image = ":image",
+)
+
+# This is an index built from the multi_arch_image outputs
+oci_image_index(
+    name = "image_index",
+    images = [
+        ":image_multi_arch",
+    ],
+)
+
 oci_push(
     name = "push",
-    image = ":image",
+    image = ":image_index",
     remote_tags = ["latest"],
     repository = "index.docker.io/filipfilmar/upspin",
 )

--- a/containers/transition.bzl
+++ b/containers/transition.bzl
@@ -1,0 +1,24 @@
+def _multi_arch_transition_impl(settings, attr):
+    return [
+        {"//command_line_option:platforms": "@rules_go//go/toolchain:linux_amd64"},
+        {"//command_line_option:platforms": "@rules_go//go/toolchain:linux_arm64"},
+    ]
+
+multi_arch_transition = transition(
+    implementation = _multi_arch_transition_impl,
+    inputs = [],
+    outputs = ["//command_line_option:platforms"],
+)
+
+def _multi_arch_image_impl(ctx):
+    return [DefaultInfo(files = depset(transitive = [dep[DefaultInfo].files for dep in ctx.attr.image]))]
+
+multi_arch_image = rule(
+    implementation = _multi_arch_image_impl,
+    attrs = {
+        "image": attr.label(cfg = multi_arch_transition),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+)


### PR DESCRIPTION
Updates `MODULE.bazel` to pull the `distroless_static` image for both `linux/amd64` and `linux/arm64/v8`.
Adds a Bazel transition in `containers/transition.bzl` to compile the go binaries for both platforms simultaneously.
Updates `containers/BUILD.bazel` to use an `oci_image_index` that bundles both architectures into a single multi-arch manifest.

This pull request has been created by an automated coding assistant, with human supervision.

Prompt: make container targets both for arm64 and amd64. send pr