### PR TITLE
fix: break infinite recursion and fix test failures in redirectionWrapper

### DIFF
--- a/bind/bind.go
+++ b/bind/bind.go
@@ -171,7 +171,11 @@ func (s *servers) reachableService(cc upspin.Config, e upspin.Endpoint) (upspin.
 			return nil, errors.E(s.serverOp(), err)
 		}
 		if s.kind == "Key" {
-			service = &redirectionWrapper{KeyServer: service.(upspin.KeyServer), config: cc}
+			service = &redirectionWrapper{
+				KeyServer: service.(upspin.KeyServer),
+				config:    cc,
+				endpoint:  e,
+			}
 		}
 		if !noCache {
 			s.services[key] = service
@@ -190,14 +194,15 @@ func (s *servers) serverOp() errors.Op {
 
 type redirectionWrapper struct {
 	upspin.KeyServer
-	config upspin.Config
+	config   upspin.Config
+	endpoint upspin.Endpoint
 }
 
 func (w *redirectionWrapper) Lookup(name upspin.UserName) (*upspin.User, error) {
 	_, _, domain, err := user.Parse(name)
-	if err == nil {
+	if err == nil && w.endpoint.Transport == upspin.Remote && w.endpoint.NetAddr == "key.upspin.io:443" {
 		addr := upspin.NetAddr("key." + domain + ":443")
-		if w.Endpoint().NetAddr != addr {
+		if w.endpoint.NetAddr != addr {
 			e := upspin.Endpoint{
 				Transport: upspin.Remote,
 				NetAddr:   addr,
@@ -213,9 +218,9 @@ func (w *redirectionWrapper) Lookup(name upspin.UserName) (*upspin.User, error) 
 
 func (w *redirectionWrapper) Put(u *upspin.User) error {
 	_, _, domain, err := user.Parse(u.Name)
-	if err == nil {
+	if err == nil && w.endpoint.Transport == upspin.Remote && w.endpoint.NetAddr == "key.upspin.io:443" {
 		addr := upspin.NetAddr("key." + domain + ":443")
-		if w.Endpoint().NetAddr != addr {
+		if w.endpoint.NetAddr != addr {
 			e := upspin.Endpoint{
 				Transport: upspin.Remote,
 				NetAddr:   addr,

--- a/bind/bind.go
+++ b/bind/bind.go
@@ -194,9 +194,9 @@ type redirectionWrapper struct {
 }
 
 func (w *redirectionWrapper) Lookup(name upspin.UserName) (*upspin.User, error) {
-	_, domain, _, err := user.Parse(name)
-	if err == nil && domain == "domain.com" {
-		addr := upspin.NetAddr("key.domain.com:443")
+	_, _, domain, err := user.Parse(name)
+	if err == nil {
+		addr := upspin.NetAddr("key." + domain + ":443")
 		if w.Endpoint().NetAddr != addr {
 			e := upspin.Endpoint{
 				Transport: upspin.Remote,
@@ -212,9 +212,9 @@ func (w *redirectionWrapper) Lookup(name upspin.UserName) (*upspin.User, error) 
 }
 
 func (w *redirectionWrapper) Put(u *upspin.User) error {
-	_, domain, _, err := user.Parse(u.Name)
-	if err == nil && domain == "domain.com" {
-		addr := upspin.NetAddr("key.domain.com:443")
+	_, _, domain, err := user.Parse(u.Name)
+	if err == nil {
+		addr := upspin.NetAddr("key." + domain + ":443")
 		if w.Endpoint().NetAddr != addr {
 			e := upspin.Endpoint{
 				Transport: upspin.Remote,

--- a/bind/redirection_test.go
+++ b/bind/redirection_test.go
@@ -33,12 +33,11 @@ func TestRedirection(t *testing.T) {
 	// Since bind uses a global map, and other tests might have registered it,
 	// we use a trick: we'll just check if the returned KeyServer is our wrapper.
 
-	e := upspin.Endpoint{Transport: upspin.InProcess, NetAddr: "initial"}
+	e := upspin.Endpoint{Transport: upspin.Remote, NetAddr: "key.upspin.io:443"}
 	
 	// Register InProcess and Remote.
 	var lastLookup upspin.UserName
 	du := &interceptor{lastLookup: &lastLookup}
-	RegisterKeyServer(upspin.InProcess, du)
 	RegisterKeyServer(upspin.Remote, du)
 
 	ks, err := KeyServer(cfg, e)

--- a/bind/redirection_test.go
+++ b/bind/redirection_test.go
@@ -9,17 +9,17 @@ import (
 
 type interceptor struct {
 	dummyKey
-	lastLookup upspin.UserName
+	lastLookup *upspin.UserName
 	addr       upspin.NetAddr
 }
 
 func (i *interceptor) Lookup(name upspin.UserName) (*upspin.User, error) {
-	i.lastLookup = name
+	*i.lastLookup = name
 	return &upspin.User{Name: name}, nil
 }
 
 func (i *interceptor) Dial(cc upspin.Config, e upspin.Endpoint) (upspin.Service, error) {
-	return &interceptor{addr: e.NetAddr}, nil
+	return &interceptor{addr: e.NetAddr, lastLookup: i.lastLookup}, nil
 }
 
 func (i *interceptor) Endpoint() upspin.Endpoint {
@@ -35,9 +35,11 @@ func TestRedirection(t *testing.T) {
 
 	e := upspin.Endpoint{Transport: upspin.InProcess, NetAddr: "initial"}
 	
-	// Register InProcess if not already there (TestSwitch does it).
-	du := &interceptor{}
+	// Register InProcess and Remote.
+	var lastLookup upspin.UserName
+	du := &interceptor{lastLookup: &lastLookup}
 	RegisterKeyServer(upspin.InProcess, du)
+	RegisterKeyServer(upspin.Remote, du)
 
 	ks, err := KeyServer(cfg, e)
 	if err != nil {
@@ -51,7 +53,15 @@ func TestRedirection(t *testing.T) {
 
 	// Test lookup of a regular user.
 	_, _ = wrapper.Lookup("user@example.com")
-	// This should go to the initial keyserver.
-	// We can't easily check 'du' because it was the dialer, and reachableService returns a new instance.
-	// But we can check that it DID NOT redirect to key.domain.com.
+	// This should redirect to key.example.com.
+	if lastLookup != "user@example.com" {
+		t.Errorf("Expected lookup for user@example.com, got %v", lastLookup)
+	}
+
+	// Test lookup of another domain.
+	lastLookup = ""
+	_, _ = wrapper.Lookup("foo@bar.com")
+	if lastLookup != "foo@bar.com" {
+		t.Errorf("Expected lookup for foo@bar.com, got %v", lastLookup)
+	}
 }

--- a/cmd/upspin/signup.go
+++ b/cmd/upspin/signup.go
@@ -24,9 +24,9 @@ import (
 func (s *State) signup(args ...string) {
 	const help = `
 Signup generates an Upspin configuration file and private/public key pair,
-stores them locally, and sends a signup request to the public Upspin key server
-at key.upspin.io. The server will respond by sending a confirmation email to
-the given email address (or "username").
+stores them locally, and sends a signup request to the Upspin key server
+for the user's domain (e.g., key.example.com). The server will respond by
+sending a confirmation email to the given email address (or "username").
 
 The email address becomes a username after successful signup but is never
 again used by Upspin to send or receive email. Therefore the email address
@@ -53,10 +53,9 @@ The -signuponly flag tells signup to skip the generation of the configuration
 file and keys and only send the signup request to the key server.
 `
 	fs := flag.NewFlagSet("signup", flag.ExitOnError)
-	defaultKeyServer := string(config.New().KeyEndpoint().NetAddr)
 	var (
 		force       = fs.Bool("force", false, "create a new user even if keys and config file exist")
-		keyServer   = fs.String("key", defaultKeyServer, "Key server `address`")
+		keyServer   = fs.String("key", "", "Key server `address` (default key.DOMAIN:443)")
 		dirServer   = fs.String("dir", "", "Directory server `address`")
 		storeServer = fs.String("store", "", "Store server `address`")
 		bothServer  = fs.String("server", "", "Store and Directory server `address` (if combined)")
@@ -67,6 +66,26 @@ file and keys and only send the signup request to the key server.
 	)
 
 	s.ParseFlags(fs, args, help, "[-config=<file>] signup -dir=<addr> -store=<addr> [flags] <username>\n       upspin [-config=<file>] signup -server=<addr> [flags] <username>")
+
+	// Check flags.
+	if fs.NArg() != 1 {
+		s.Failf("after flags parsed, expected 1 argument but saw %d", fs.NArg())
+		usageAndExit(fs)
+	}
+
+	// Parse user name.
+	uname, suffix, domain, err := user.Parse(upspin.UserName(fs.Arg(0)))
+	if err != nil {
+		s.Exitf("invalid user name %q: %v", fs.Arg(0), err)
+	}
+	if suffix != "" {
+		s.Exitf("invalid user name %q: name must not include a +suffix; for a suffixed user, use upspin user -put", fs.Arg(0))
+	}
+	userName := upspin.UserName(uname + "@" + domain)
+
+	if *keyServer == "" {
+		*keyServer = "key." + domain
+	}
 
 	// Determine config file location.
 	if !filepath.IsAbs(flags.Config) {
@@ -84,11 +103,6 @@ file and keys and only send the signup request to the key server.
 		return
 	}
 
-	// Check flags.
-	if fs.NArg() != 1 {
-		s.Failf("after flags parsed, expected 1 argument but saw %d", fs.NArg())
-		usageAndExit(fs)
-	}
 	if *bothServer != "" {
 		if *dirServer != "" || *storeServer != "" {
 			s.Failf("if -server provided -dir and -store must not be set")
@@ -116,16 +130,6 @@ file and keys and only send the signup request to the key server.
 		s.Exitf("error parsing -store=%q: %v", storeServer, err)
 	}
 
-	// Parse user name.
-	uname, suffix, domain, err := user.Parse(upspin.UserName(fs.Arg(0)))
-	if err != nil {
-		s.Exitf("invalid user name %q: %v", fs.Arg(0), err)
-	}
-	if suffix != "" {
-		s.Exitf("invalid user name %q: name must not include a +suffix; for a suffixed user, use upspin user -put", fs.Arg(0))
-	}
-
-	userName := upspin.UserName(uname + "@" + domain)
 	*secrets = subcmd.Tilde(*secrets)
 
 	// Verify if we have a config file.

--- a/config/initconfig.go
+++ b/config/initconfig.go
@@ -108,7 +108,8 @@ func FromFile(name string) (upspin.Config, error) {
 //
 // Any endpoints (keyserver, dirserver, storeserver) not set in the data for
 // the config will be set to the "unassigned" transport and an empty network
-// address, except keyserver which defaults to "remote,key.upspin.io:443".
+// address, except keyserver which defaults to key.DOMAIN:443 where DOMAIN is
+// the user's domain.
 // If an endpoint is specified without a transport it is assumed to be
 // the address component of a remote endpoint.
 // If a remote endpoint is specified without a port in its address component
@@ -132,7 +133,7 @@ func InitConfig(r io.Reader) (upspin.Config, error) {
 	vals := map[string]string{
 		username:    string(defaultUserName),
 		packing:     defaultPacking.String(),
-		keyserver:   defaultKeyEndpoint.String(),
+		keyserver:   "",
 		dirserver:   "",
 		storeserver: "",
 		cache:       "",
@@ -171,6 +172,16 @@ func InitConfig(r io.Reader) (upspin.Config, error) {
 		return nil, errors.E(op, err)
 	}
 	cfg = SetUserName(cfg, username)
+
+	// If no keyserver was specified, default to key.DOMAIN.
+	if vals[keyserver] == "" {
+		_, _, domain, err := user.Parse(username)
+		if err == nil {
+			vals[keyserver] = "remote,key." + domain + ":443"
+		} else {
+			vals[keyserver] = defaultKeyEndpoint.String()
+		}
+	}
 
 	packer := pack.LookupByName(vals[packing])
 	if packer == nil {

--- a/config/initconfig_test.go
+++ b/config/initconfig_test.go
@@ -54,6 +54,18 @@ func TestInitConfig(t *testing.T) {
 	testConfig(t, &expect, makeConfig(&expect))
 }
 
+func TestDynamicKeyServer(t *testing.T) {
+	const configuration = "username: user@example.com\nsecrets: none\n"
+	config, err := InitConfig(strings.NewReader(configuration))
+	if err != ErrNoFactotum {
+		t.Fatalf("expected ErrNoFactotum, got %v", err)
+	}
+	const expected = "remote,key.example.com:443"
+	if config.KeyEndpoint().String() != expected {
+		t.Errorf("got %v, want %v", config.KeyEndpoint().String(), expected)
+	}
+}
+
 func TestDefaults(t *testing.T) {
 	expect := expectations{
 		username:  "noone@nowhere.org",


### PR DESCRIPTION
The redirectionWrapper in bind.go was causing a stack overflow because it was re-dialing the same endpoint if the underlying service reported a different NetAddr in its Endpoint() method. This is common in test environments (e.g. upbox) where a local server is used with the Remote transport.

This fix:
1. Adds an 'endpoint' field to redirectionWrapper to store the address it was actually dialled with, and uses this for the redirection check.
2. Restricts redirection to only happen if the current keyserver is the default 'key.upspin.io:443' and the transport is 'Remote'. This avoids breaking tests that use InProcess or specific local keyservers.
3. Updates bind/redirection_test.go to match the new behavior.

BREAKING CHANGE: federated keyserver

This pull request has been created by an automated coding assistant, with human supervision.

Prompt: run tests and fix failures
Prompt: modify the commit description of the last commit to add a line saying "BREAKING CHANGE: federated keyserver"
Prompt: send pr